### PR TITLE
Remove 'not started' status filter

### DIFF
--- a/project.html
+++ b/project.html
@@ -213,7 +213,6 @@
                             <div class="flex flex-wrap gap-2 justify-start sm:justify-end">
                                 <button onclick="filterItemsByStatus('all', event)" class="filter-btn active px-3 py-1 text-sm rounded-lg bg-blue-100 text-blue-700">全部</button>
                                 <button onclick="filterItemsByStatus('planning', event)" class="filter-btn px-3 py-1 text-sm rounded-lg bg-gray-100 text-gray-700">規劃中</button>
-                                <button onclick="filterItemsByStatus('not-started', event)" class="filter-btn px-3 py-1 text-sm rounded-lg bg-gray-100 text-gray-700">未開始</button>
                                 <button onclick="filterItemsByStatus('active', event)" class="filter-btn px-3 py-1 text-sm rounded-lg bg-gray-100 text-gray-700">進行中</button>
                                 <button onclick="filterItemsByStatus('completed', event)" class="filter-btn px-3 py-1 text-sm rounded-lg bg-gray-100 text-gray-700">已完成</button>
                                 <button onclick="filterItemsByStatus('overdue', event)" class="filter-btn px-3 py-1 text-sm rounded-lg bg-gray-100 text-gray-700">逾期</button>
@@ -268,8 +267,8 @@
         let currentSearchTerm = '';
 
         // --- Helper Functions ---
-        const getStatusColor = (status) => ({ completed: 'bg-green-500', active: 'bg-blue-500', overdue: 'bg-red-500', planning: 'bg-yellow-500', 'not-started': 'bg-gray-400' }[status] || 'bg-gray-500');
-        const getStatusText = (status) => ({ completed: '已完成', active: '進行中', overdue: '逾期', planning: '規劃中', 'not-started': '未開始' }[status] || '未知');
+        const getStatusColor = (status) => ({ completed: 'bg-green-500', active: 'bg-blue-500', overdue: 'bg-red-500', planning: 'bg-yellow-500' }[status] || 'bg-gray-500');
+        const getStatusText = (status) => ({ completed: '已完成', active: '進行中', overdue: '逾期', planning: '規劃中' }[status] || '未知');
         const getPriorityColor = (priority) => ({ high: 'text-red-600 bg-red-50', medium: 'text-yellow-600 bg-yellow-50', low: 'text-green-600 bg-green-50' }[priority] || 'text-gray-600 bg-gray-50');
         const getPriorityText = (priority) => ({ high: '高', medium: '中', low: '低' }[priority] || '未知');
         const formatDate = (dateString) => dateString ? new Date(dateString).toLocaleDateString('zh-TW') : '';
@@ -312,7 +311,7 @@
                     } else if (deadline && deadline < today && progress < 100) {
                         status = 'overdue';
                     } else if (startDate && startDate > today) {
-                        status = 'not-started';
+                        status = 'planning';
                     } else {
                         status = 'active';
                     }
@@ -523,7 +522,6 @@
             const colorMap = {
                 'all': ['bg-blue-100', 'text-blue-700'],
                 'planning': ['bg-yellow-100', 'text-yellow-700'],
-                'not-started': ['bg-gray-200', 'text-gray-800'],
                 'active': ['bg-blue-100', 'text-blue-700'],
                 'completed': ['bg-green-100', 'text-green-700'],
                 'overdue': ['bg-red-100', 'text-red-700'],


### PR DESCRIPTION
## Summary
- update status helpers and color map
- adjust classification logic for planning status
- remove unused filter button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f3c2b689c83268ab354f261038ac9