### PR TITLE
Remove planning project link in admin page

### DIFF
--- a/Project-admin.html
+++ b/Project-admin.html
@@ -77,7 +77,6 @@
                     <div>
                         <div class="flex items-center justify-between mb-2">
                             <label for="item-status" class="block text-sm font-medium text-gray-700">狀態 (必填)</label>
-                            <a href="project.html?status=planning" class="text-blue-600 text-sm underline">查看規劃中專案</a>
                         </div>
                         <select id="item-status" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500" required>
                             <option value="planning">規劃中</option>


### PR DESCRIPTION
## Summary
- remove the link to "查看規劃中專案" from the status field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f84f7a24883269c69d3150d2dda6d