### PR TITLE
Add meeting type support

### DIFF
--- a/Project-admin.html
+++ b/Project-admin.html
@@ -52,6 +52,7 @@
                             <option value="task">任務</option>
                             <option value="project">專案</option>
                             <option value="activity">活動</option>
+                            <option value="meeting">會議</option>
                         </select>
                     </div>
                 </div>
@@ -319,6 +320,8 @@
                     return '<span class="text-xs font-normal text-green-500">(任務)</span>';
                 case 'activity':
                     return '<span class="text-xs font-normal text-purple-500">(活動)</span>';
+                case 'meeting':
+                    return '<span class="text-xs font-normal text-indigo-500">(會議)</span>';
                 default:
                     return '';
             }

--- a/project.html
+++ b/project.html
@@ -290,13 +290,19 @@
         const getPriorityColor = (priority) => ({ high: 'text-red-600 bg-red-50', medium: 'text-yellow-600 bg-yellow-50', low: 'text-green-600 bg-green-50' }[priority] || 'text-gray-600 bg-gray-50');
         const getPriorityText = (priority) => ({ high: '高', medium: '中', low: '低' }[priority] || '未知');
         const formatDate = (dateString) => dateString ? new Date(dateString).toLocaleDateString('zh-TW') : '';
-        const getTypeText = (type) => ({ project: '專案', task: '任務', activity: '活動' }[type] || '項目');
-        const getTypeStyle = (type) => {
+        const getTypeText = (type) => ({ project: '專案', task: '任務', activity: '活動', meeting: '會議' }[type] || '項目');
+        const getTypeStyle = (type, status) => {
             switch(type) {
-                case 'project': return 'text-blue-700';
-                case 'task': return 'text-green-700';
-                case 'activity': return 'text-purple-700';
-                default: return 'text-gray-500';
+                case 'project':
+                    return 'text-blue-700';
+                case 'task':
+                    return 'text-green-700';
+                case 'activity':
+                    return 'text-purple-700';
+                case 'meeting':
+                    return status === 'completed' ? 'text-gray-400' : 'text-indigo-700';
+                default:
+                    return 'text-gray-500';
             }
         };
 
@@ -379,7 +385,7 @@
                     <div class="flex-grow">
                         <div class="flex justify-between items-start mb-3">
                             <div class="flex-1">
-                                <h4 class="font-semibold text-gray-900 mb-1">${item.name} <span class="text-xs font-normal ${getTypeStyle(item.type)}">(${getTypeText(item.type)})</span></h4>
+                                <h4 class="font-semibold text-gray-900 mb-1">${item.name} <span class="text-xs font-normal ${getTypeStyle(item.type, item.status)}">(${getTypeText(item.type)})</span></h4>
                                 ${item.description ? `<p class="text-sm text-gray-500 mt-1 mb-2 whitespace-pre-wrap">${item.description}</p>` : ''}
                                 <p class="text-sm text-gray-600">主要負責: ${item.assignees.join(', ')}</p>
                                 ${item.collaborators && item.collaborators.length > 0 ? `<p class="text-sm text-gray-600">協助: ${item.collaborators.join(', ')}</p>` : ''}
@@ -396,7 +402,7 @@
                             <div class="w-full bg-gray-200 rounded-full h-2"><div class="progress-bar h-2 rounded-full ${getStatusColor(item.status)}" style="width: ${item.progress}%"></div></div>
                         </div>
                         <div class="flex justify-between items-center text-sm">
-                            <span class="text-gray-600">日期: ${formatDate(item.startDate)} - ${item.deadline ? formatDate(item.deadline) : (item.type === 'activity' ? '迄今 (進行中)' : '迄今')}</span>
+                            <span class="text-gray-600">日期: ${formatDate(item.startDate)} - ${item.deadline ? formatDate(item.deadline) : ((item.type === 'activity' || item.type === 'meeting') ? '迄今 (進行中)' : '迄今')}</span>
                             ${item.status === 'overdue' ? '<span class="text-red-600 font-medium">⚠️ 已逾期</span>' : ''}
                         </div>
                     </div>
@@ -416,7 +422,7 @@
 
                 const projectCount = memberItems.filter(item => item.type === 'project').length;
                 const taskCount = memberItems.filter(item => item.type === 'task').length;
-                const activityCount = memberItems.filter(item => item.type === 'activity').length;
+                const activityCount = memberItems.filter(item => item.type === 'activity' || item.type === 'meeting').length;
 
                 const isActive = name === currentMemberFilter;
 
@@ -441,12 +447,13 @@
         }
 
         function updateStats(itemsToCount) {
-            const activities = itemsToCount.filter(item => item.type && item.type.toLowerCase() === 'activity');
+            const activities = itemsToCount.filter(item => item.type && (item.type.toLowerCase() === 'activity' || item.type.toLowerCase() === 'meeting'));
+            const nonMeeting = itemsToCount.filter(item => item.type !== 'meeting');
 
-            document.getElementById('totalTasks').textContent = itemsToCount.length;
-            document.getElementById('activeTasks').textContent = itemsToCount.filter(t => t.status === 'active').length;
-            document.getElementById('overdueTasks').textContent = itemsToCount.filter(t => t.status === 'overdue').length;
-            document.getElementById('completedTasks').textContent = itemsToCount.filter(t => t.status === 'completed').length;
+            document.getElementById('totalTasks').textContent = nonMeeting.length;
+            document.getElementById('activeTasks').textContent = nonMeeting.filter(t => t.status === 'active').length;
+            document.getElementById('overdueTasks').textContent = nonMeeting.filter(t => t.status === 'overdue').length;
+            document.getElementById('completedTasks').textContent = nonMeeting.filter(t => t.status === 'completed').length;
             document.getElementById('activityCount').textContent = activities.length;
         }
 
@@ -831,7 +838,7 @@ ${summary}
             const itemsForDisplay = allActivities.filter(item => {
                 const yearMatch = currentYearFilter === 'all' || (item.startDate && new Date(item.startDate).getFullYear() == currentYearFilter);
                 const groupMatch = currentGroupFilter === 'all' || item.group == currentGroupFilter;
-                const typeMatch = item.type && item.type.toLowerCase() === 'activity';
+                const typeMatch = item.type && (item.type.toLowerCase() === 'activity' || item.type.toLowerCase() === 'meeting');
                 return yearMatch && groupMatch && typeMatch;
             });
 


### PR DESCRIPTION
## Summary
- add meeting option to admin dropdown
- show meeting label in admin table
- include meeting tag in dashboard items
- update stats and filters to handle meetings

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687fb037cf7c8326b7e510915f09340c