### PR TITLE
移除問答並以條列式推播訊息

### DIFF
--- a/project.html
+++ b/project.html
@@ -260,10 +260,7 @@
             <button id="closeChatBot" class="text-white text-xl leading-none">&times;</button>
         </div>
         <div id="chatBotMessages" class="p-4 space-y-2 text-sm overflow-y-auto max-h-60"></div>
-        <form id="chatBotForm" class="flex border-t">
-            <input id="chatBotInput" type="text" placeholder="輸入問題..." class="flex-grow p-2 text-sm focus:outline-none" />
-            <button type="submit" class="px-3 text-indigo-600 font-semibold">送出</button>
-        </form>
+        <!-- Push-only mode, no user input -->
     </div>
 
     <script>
@@ -991,7 +988,7 @@ ${summary}
             return `本頁目前共有 ${projects + tasks + activities + meetings} 項目，其中專案 ${projects} 件、任務 ${tasks} 件、活動 ${activities} 場、會議 ${meetings} 次。進行中 ${active} 項，已完成 ${completed} 項，逾期 ${overdue} 項。`;
         }
 
-        function generateMonthlySummary() {
+        function generateMonthlySummaryHTML() {
             const year = currentDate.getFullYear();
             const month = currentDate.getMonth();
 
@@ -1012,11 +1009,14 @@ ${summary}
                 summaryByGroup[item.group].push(item.name);
             });
 
-            const groupSummaryText = Object.entries(summaryByGroup).map(([g, items]) =>
-                `${groupData[g] || g}: ${items.join('、')}`
-            ).join('；');
+            const bullets = [`本月已完成 ${completedCount} 個任務或專案`];
+            Object.entries(summaryByGroup).forEach(([g, items]) => {
+                bullets.push(`${groupData[g] || g}: ${items.join('、')}`);
+            });
 
-            return `本月已完成 ${completedCount} 個任務或專案。${groupSummaryText ? ' 本月大事紀：' + groupSummaryText : ''}`;
+            return '<ul class="list-disc pl-5 space-y-1">' +
+                bullets.map(t => `<li>${t}</li>`).join('') +
+                '</ul>';
         }
 
         function setupChatBot() {
@@ -1024,25 +1024,13 @@ ${summary}
             const container = document.getElementById('chatBotContainer');
             const closeBtn = document.getElementById('closeChatBot');
             const messages = document.getElementById('chatBotMessages');
-            const form = document.getElementById('chatBotForm');
-            const input = document.getElementById('chatBotInput');
 
             openBtn.addEventListener('click', () => {
                 container.classList.remove('hidden');
-                messages.innerHTML = `<div class="text-gray-700">🤖 ${generateMonthlySummary()}</div>`;
+                messages.innerHTML = generateMonthlySummaryHTML();
             });
 
             closeBtn.addEventListener('click', () => container.classList.add('hidden'));
-
-            form.addEventListener('submit', (e) => {
-                e.preventDefault();
-                const text = input.value.trim();
-                if (!text) return;
-                messages.innerHTML += `<div class="text-right text-gray-800">${text}</div>`;
-                messages.innerHTML += `<div class="text-gray-700">🤖 ${generateMonthlySummary()}</div>`;
-                messages.scrollTop = messages.scrollHeight;
-                input.value = '';
-            });
         }
 
         // --- Initial Load ---


### PR DESCRIPTION
## Summary
- 移除聊天室輸入表單，改為只推播訊息
- `generateMonthlySummaryHTML` 以 `ul` 列表呈現月摘要
- 開啟機器人時直接顯示條列摘要

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688045b8c3948326b69839c056746e69