### PR TITLE
Protect admin pages with login

### DIFF
--- a/Project-admin.html
+++ b/Project-admin.html
@@ -16,6 +16,11 @@
             padding: 8px;
         }
     </style>
+    <script>
+        if (!localStorage.getItem('dashboardLoggedIn')) {
+            window.location.href = 'project.html';
+        }
+    </script>
 </head>
 <body class="bg-slate-50 min-h-screen">
     <div class="container mx-auto px-4 py-8 max-w-7xl">

--- a/admin.html
+++ b/admin.html
@@ -13,6 +13,11 @@
         .toast.show { transform: translateY(0); opacity: 1; }
         input[type="date"]:invalid::-webkit-calendar-picker-indicator { opacity: 0.6; }
     </style>
+    <script>
+        if (!localStorage.getItem('dashboardLoggedIn')) {
+            window.location.href = 'index.html';
+        }
+    </script>
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
     <div class="container mx-auto px-4 py-8 max-w-6xl">

--- a/index.html
+++ b/index.html
@@ -209,6 +209,7 @@
             if (username === '4200' && password === '4200') {
                 loginMessage.textContent = '登入成功！';
                 loginMessage.className = 'text-center mb-4 font-medium text-green-500';
+                localStorage.setItem('dashboardLoggedIn', 'true');
                 setTimeout(() => {
                     loginModal.classList.add('hidden');
                     window.location.href = 'admin.html';

--- a/project.html
+++ b/project.html
@@ -634,6 +634,7 @@
                 if (username === '4200' && password === '4200') {
                     loginMessage.textContent = '登入成功！';
                     loginMessage.className = 'text-center mb-4 font-medium text-green-500';
+                    localStorage.setItem('dashboardLoggedIn', 'true');
                     setTimeout(() => {
                         window.location.href = 'https://luyun1224.github.io/cmh4200/Project-admin.html';
                     }, 1500);
@@ -1138,7 +1139,7 @@ ${summary}
             loadingOverlay.classList.remove('hidden');
             try {
                 await refreshData(); // Initial data load
-                showWeeklySummary();
+                // showWeeklySummary(); // Disable auto popup of weekly summary
                 if (paramStatus) {
                     const btn = document.querySelector(`.filter-btn[onclick*="${paramStatus}"]`);
                     if (btn) filterItemsByStatus(paramStatus, { target: btn });


### PR DESCRIPTION
## Summary
- remove automatic `本週重點` modal on project page
- record login status to `localStorage`
- enforce login before loading admin pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880e154a0688326b8684f76fa60be5a