### PR TITLE
Add progress checkpoints and weekly comparison

### DIFF
--- a/Project-admin.html
+++ b/Project-admin.html
@@ -110,10 +110,21 @@
                         <input type="date" id="item-deadline" class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500">
                     </div>
                 </div>
-                 <div class="pt-2">
+                <div class="pt-2">
                     <label for="item-progress" class="block text-sm font-medium text-gray-700">進度 (%)</label>
-                    <input type="range" id="item-progress" min="0" max="100" value="0" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
-                    <div class="text-center text-sm text-gray-600 mt-1"><span id="progress-value">0</span>%</div>
+                    <div class="flex items-center space-x-2">
+                        <button type="button" id="decrease-progress" class="px-2 py-1 bg-gray-200 rounded">-10</button>
+                        <input type="number" id="item-progress" min="0" max="100" step="10" value="0" class="flex-1 px-3 py-2 border border-gray-300 rounded-lg">
+                        <button type="button" id="increase-progress" class="px-2 py-1 bg-gray-200 rounded">+10</button>
+                    </div>
+                </div>
+                <div class="pt-2">
+                    <label for="item-lastweek-progress" class="block text-sm font-medium text-gray-700">上週進度 (%)</label>
+                    <input type="number" id="item-lastweek-progress" min="0" max="100" step="10" value="0" class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                </div>
+                <div class="pt-2">
+                    <label for="item-help-message" class="block text-sm font-medium text-gray-700">求救訊息 / 停滯原因</label>
+                    <textarea id="item-help-message" rows="2" class="w-full px-3 py-2 border border-gray-300 rounded-lg"></textarea>
                 </div>
                 <div class="flex justify-end space-x-4 pt-4">
                     <button type="button" id="cancel-edit-btn" class="bg-gray-200 text-gray-800 px-6 py-2 rounded-lg hover:bg-gray-300 transition-colors hidden">取消編輯</button>
@@ -204,8 +215,11 @@
         const formTitle = document.getElementById('form-title');
         const saveBtn = document.getElementById('save-item-btn');
         const cancelBtn = document.getElementById('cancel-edit-btn');
-        const progressSlider = document.getElementById('item-progress');
-        const progressValue = document.getElementById('progress-value');
+        const progressInput = document.getElementById('item-progress');
+        const lastWeekProgressInput = document.getElementById('item-lastweek-progress');
+        const helpMessageInput = document.getElementById('item-help-message');
+        const increaseBtn = document.getElementById('increase-progress');
+        const decreaseBtn = document.getElementById('decrease-progress');
         const groupSelect = document.getElementById('item-group');
         const otherGroupWrapper = document.getElementById('other-group-wrapper');
         const otherGroupNameInput = document.getElementById('other-group-name');
@@ -407,8 +421,9 @@
         
         function resetForm() {
             form.reset();
-            progressSlider.value = 0;
-            progressValue.textContent = 0;
+            progressInput.value = 0;
+            lastWeekProgressInput.value = 0;
+            helpMessageInput.value = '';
             document.getElementById('item-id').value = '';
             formTitle.textContent = '新增項目';
             saveBtn.innerHTML = '<i class="fas fa-plus mr-2"></i>新增項目';
@@ -443,8 +458,9 @@
             // Use the new formatting function for dates
             document.getElementById('item-start-date').value = formatDateForInput(item.startDate);
             document.getElementById('item-deadline').value = formatDateForInput(item.deadline);
-            progressSlider.value = item.progress;
-            progressValue.textContent = item.progress;
+            progressInput.value = item.progress;
+            lastWeekProgressInput.value = item.lastWeekProgress || 0;
+            helpMessageInput.value = item.helpMessage || '';
 
             [...assigneesSelect.options].forEach(opt => { opt.selected = item.assignees.includes(opt.value); });
             [...collaboratorsSelect.options].forEach(opt => { opt.selected = item.collaborators.includes(opt.value); });
@@ -507,8 +523,13 @@
         }
 
         // --- Event Listeners ---
-        progressSlider.addEventListener('input', (e) => {
-            progressValue.textContent = e.target.value;
+        increaseBtn.addEventListener('click', () => {
+            let val = parseInt(progressInput.value) || 0;
+            progressInput.value = Math.min(100, val + 10);
+        });
+        decreaseBtn.addEventListener('click', () => {
+            let val = parseInt(progressInput.value) || 0;
+            progressInput.value = Math.max(0, val - 10);
         });
 
         groupSelect.addEventListener('change', (e) => {
@@ -565,7 +586,9 @@
                 priority: document.getElementById('item-priority').value,
                 startDate: document.getElementById('item-start-date').value,
                 deadline: document.getElementById('item-deadline').value,
-                progress: parseInt(progressSlider.value),
+                progress: parseInt(progressInput.value),
+                lastWeekProgress: parseInt(lastWeekProgressInput.value) || 0,
+                helpMessage: helpMessageInput.value
             };
 
             const result = await handleApiRequest('saveItem', { item: itemData }, saveBtn);

--- a/project.html
+++ b/project.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>教學中心 - 專案進度儀表板</title>
+    <title>教學部-專案進度儀表板</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <style>
@@ -66,6 +66,16 @@
         /* Green */
         .text-green-500, .text-green-600, .text-green-700 { color: var(--dark-green) !important; }
         .bg-green-500, .bg-green-600 { background-color: var(--dark-green) !important; }
+
+        /* Overdue glow */
+        @keyframes pulse-red {
+            0% { box-shadow: 0 0 0 0 rgba(220, 38, 38, 0.7); }
+            100% { box-shadow: 0 0 10px 4px rgba(220, 38, 38, 0.7); }
+        }
+        .overdue-glow {
+            animation: pulse-red 1s infinite alternate;
+            border-color: rgba(220, 38, 38, 0.8);
+        }
         .hover\:bg-green-700:hover { background-color: var(--dark-green) !important; }
         .border-green-500, .border-green-600 { border-color: var(--dark-green) !important; }
         .bg-green-100 { background-color: var(--lime-green) !important; }
@@ -158,7 +168,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 py-4">
             <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
                 <div class="text-center sm:text-left">
-                    <h1 class="text-2xl font-bold text-gray-900">教學中心 - 專案進度儀表板</h1>
+                    <h1 class="text-2xl font-bold text-gray-900">教學部-專案進度儀表板</h1>
                     <p class="text-sm text-gray-500 mt-1">即時追蹤所有進行中的專案與任務</p>
                 </div>
                 <div class="flex flex-wrap items-center justify-center sm:justify-end gap-2 sm:gap-4">
@@ -274,7 +284,10 @@
         
         // This constant represents the current date for all calculations.
         // Set to the user-provided context: July 22, 2025.
-        const currentDate = new Date('2025-07-22T21:21:00+08:00');
+const currentDate = new Date('2025-07-22T21:21:00+08:00');
+
+        // Standardized project checkpoints for each 10% increment
+        const standardSteps = ['啟動', '需求分析', '規劃', '設計', '開發', '測試', '部署', '驗收', '結案準備', '完成'];
 
         const staffData = [
             { name: '廖家德', group: 'teaching-center' }, { name: '劉雯', group: 'teaching-center' }, { name: '楊依玲', group: 'teaching-center' }, { name: '高瑞穗', group: 'teaching-center' },
@@ -309,6 +322,10 @@
         const getStatusText = (status) => ({ completed: '已完成', active: '進行中', overdue: '逾期', planning: '規劃中' }[status] || '未知');
         const getPriorityColor = (priority) => ({ high: 'text-red-600 bg-red-50', medium: 'text-yellow-600 bg-yellow-50', low: 'text-green-600 bg-green-50' }[priority] || 'text-gray-600 bg-gray-50');
         const getPriorityText = (priority) => ({ high: '高', medium: '中', low: '低' }[priority] || '未知');
+        const getStandardStep = (progress) => {
+            const index = Math.min(standardSteps.length - 1, Math.floor(progress / 10));
+            return standardSteps[index] || '';
+        };
         const formatDate = (dateString) => dateString ? new Date(dateString).toLocaleDateString('zh-TW') : '';
         const getTypeText = (type) => ({ project: '專案', task: '任務', activity: '活動', meeting: '會議' }[type] || '項目');
         const getTypeStyle = (type, status) => {
@@ -356,7 +373,12 @@
                         finalStatus = 'overdue';
                     }
 
-                    return { ...item, status: finalStatus };
+                    return {
+                        ...item,
+                        status: finalStatus,
+                        lastWeekProgress: item.lastWeekProgress ? parseInt(item.lastWeekProgress) : 0,
+                        helpMessage: item.helpMessage || ''
+                    };
                 });
             } catch (error) {
                 console.error("Failed to fetch items:", error);
@@ -405,7 +427,7 @@
             }
 
             itemsList.innerHTML = filteredItems.map(item => `
-                <div class="bg-white border border-gray-100 rounded-lg p-4 flex flex-col h-full shadow-sm hover:-translate-y-1 hover:shadow-lg transition-all duration-200">
+                <div class="bg-white border rounded-lg p-4 flex flex-col h-full shadow-sm hover:-translate-y-1 hover:shadow-lg transition-all duration-200 ${item.status === 'overdue' ? 'bg-red-50 overdue-glow' : 'border-gray-100'}">
                     <div class="flex-grow">
                         <div class="flex justify-between items-start mb-3">
                             <div class="flex-1">
@@ -423,12 +445,13 @@
                     <div>
                         <div class="mb-3">
                             <div class="flex justify-between text-sm mb-1"><span>進度</span><span>${item.progress}%</span></div>
-                            <div class="w-full bg-gray-200 rounded-full h-2"><div class="progress-bar h-2 rounded-full ${getStatusColor(item.status)}" style="width: ${item.progress}%"></div></div>
+                            <div class="w-full bg-gray-200 rounded-full h-2" title="目前步驟: ${getStandardStep(item.progress)}"><div class="progress-bar h-2 rounded-full ${getStatusColor(item.status)}" style="width: ${item.progress}%"></div></div>
                         </div>
                         <div class="flex justify-between items-center text-sm">
                             <span class="text-gray-600">日期: ${formatDate(item.startDate)} - ${item.deadline ? formatDate(item.deadline) : ((item.type === 'activity' || item.type === 'meeting') ? '迄今 (進行中)' : '迄今')}</span>
                             ${item.status === 'overdue' ? '<span class="text-red-600 font-medium">⚠️ 已逾期</span>' : ''}
                         </div>
+                        ${item.status === 'overdue' && item.helpMessage ? `<p class="text-red-700 text-sm mt-2">求救訊息：${item.helpMessage}</p>` : ''}
                     </div>
                 </div>`).join('');
         }
@@ -733,12 +756,14 @@
                 const overdueItems = allActivities.filter(item => item.status === 'overdue');
                 const highRiskItems = allActivities.filter(item => new Date(item.deadline) > currentDate && new Date(item.deadline) < fourteenDaysFromNow && item.progress < 50);
                 
+                const stagnant = allActivities.filter(i => (i.progress - (i.lastWeekProgress || 0)) <= 0 && i.status !== 'completed');
                 const summary = `
                     - 總項目數: ${allActivities.length}
                     - 進行中: ${allActivities.filter(i => i.status === 'active').length}
                     - 已完成: ${allActivities.filter(i => i.status === 'completed').length}
                     - 逾期項目: ${overdueItems.length} (${overdueItems.map(i => i.name).join(', ') || '無'})
                     - 高風險項目 (14天內到期且進度低於50%): ${highRiskItems.length} (${highRiskItems.map(i => `${i.name} - ${i.progress}%`).join(', ') || '無'})
+                    - 進度停滯項目: ${stagnant.length} (${stagnant.map(i => `${i.name}`).join(', ') || '無'})
                 `;
 
                 // ** Updated prompt with conditional instructions **
@@ -1051,6 +1076,13 @@ ${summary}
                 <ul class="list-disc pl-5 space-y-1">
                     <li>目前無逾期項目，專案時程控制良好！</li>
                 </ul>`;
+            }
+
+            const stagnantItems = allActivities.filter(i => (i.progress - (i.lastWeekProgress || 0)) <= 0 && i.status !== 'completed');
+            if (stagnantItems.length > 0) {
+                progressHTML += `<p class="font-semibold text-yellow-600 mt-2">⚠️ 進度停滯項目：</p><ul class="list-disc pl-5 space-y-1">` +
+                    stagnantItems.map(i => `<li>${i.name}：${i.progress}% (上週 ${i.lastWeekProgress || 0}%)</li>`).join('') +
+                    '</ul>';
             }
 
             // --- Coming Up ---


### PR DESCRIPTION
## Summary
- rename dashboard title to 教學部-專案進度儀表板
- add overdue glow effect and help message on cards
- show standardized steps on progress bars
- store last week progress and help message in admin
- change progress input to 10% step buttons
- include stagnant project check in AI suggestions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884c479703c8326b55375a7ed2b43cb