### PR TITLE
Update admin progress slider

### DIFF
--- a/Project-admin.html
+++ b/Project-admin.html
@@ -114,17 +114,15 @@
                     <label for="item-progress" class="block text-sm font-medium text-gray-700">進度 (%)</label>
                     <div class="flex items-center space-x-2">
                         <button type="button" id="decrease-progress" class="px-2 py-1 bg-gray-200 rounded">-10</button>
-                        <input type="number" id="item-progress" min="0" max="100" step="10" value="0" class="flex-1 px-3 py-2 border border-gray-300 rounded-lg">
+                        <input type="range" id="item-progress" min="0" max="100" step="10" value="0" class="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
                         <button type="button" id="increase-progress" class="px-2 py-1 bg-gray-200 rounded">+10</button>
+                        <span class="text-sm text-gray-600 ml-2"><span id="progress-value">0</span>%</span>
                     </div>
                 </div>
                 <div class="pt-2">
-                    <label for="item-lastweek-progress" class="block text-sm font-medium text-gray-700">上週進度 (%)</label>
-                    <input type="number" id="item-lastweek-progress" min="0" max="100" step="10" value="0" class="w-full px-3 py-2 border border-gray-300 rounded-lg">
-                </div>
-                <div class="pt-2">
-                    <label for="item-help-message" class="block text-sm font-medium text-gray-700">求救訊息 / 停滯原因</label>
-                    <textarea id="item-help-message" rows="2" class="w-full px-3 py-2 border border-gray-300 rounded-lg"></textarea>
+                    <label for="item-help-message" class="block text-sm font-medium text-gray-700">留言板</label>
+                    <textarea id="item-help-message" rows="2" class="w-full px-3 py-2 border border-gray-300 rounded-lg" placeholder="專案進度說明(停滯原因...等)"></textarea>
+                    <p class="text-xs text-gray-400 mt-1">專案進度說明(停滯原因...等)</p>
                 </div>
                 <div class="flex justify-end space-x-4 pt-4">
                     <button type="button" id="cancel-edit-btn" class="bg-gray-200 text-gray-800 px-6 py-2 rounded-lg hover:bg-gray-300 transition-colors hidden">取消編輯</button>
@@ -216,7 +214,7 @@
         const saveBtn = document.getElementById('save-item-btn');
         const cancelBtn = document.getElementById('cancel-edit-btn');
         const progressInput = document.getElementById('item-progress');
-        const lastWeekProgressInput = document.getElementById('item-lastweek-progress');
+        const progressValue = document.getElementById('progress-value');
         const helpMessageInput = document.getElementById('item-help-message');
         const increaseBtn = document.getElementById('increase-progress');
         const decreaseBtn = document.getElementById('decrease-progress');
@@ -422,7 +420,7 @@
         function resetForm() {
             form.reset();
             progressInput.value = 0;
-            lastWeekProgressInput.value = 0;
+            progressValue.textContent = 0;
             helpMessageInput.value = '';
             document.getElementById('item-id').value = '';
             formTitle.textContent = '新增項目';
@@ -459,7 +457,7 @@
             document.getElementById('item-start-date').value = formatDateForInput(item.startDate);
             document.getElementById('item-deadline').value = formatDateForInput(item.deadline);
             progressInput.value = item.progress;
-            lastWeekProgressInput.value = item.lastWeekProgress || 0;
+            progressValue.textContent = item.progress;
             helpMessageInput.value = item.helpMessage || '';
 
             [...assigneesSelect.options].forEach(opt => { opt.selected = item.assignees.includes(opt.value); });
@@ -526,10 +524,16 @@
         increaseBtn.addEventListener('click', () => {
             let val = parseInt(progressInput.value) || 0;
             progressInput.value = Math.min(100, val + 10);
+            progressValue.textContent = progressInput.value;
         });
         decreaseBtn.addEventListener('click', () => {
             let val = parseInt(progressInput.value) || 0;
             progressInput.value = Math.max(0, val - 10);
+            progressValue.textContent = progressInput.value;
+        });
+
+        progressInput.addEventListener('input', (e) => {
+            progressValue.textContent = e.target.value;
         });
 
         groupSelect.addEventListener('change', (e) => {
@@ -587,7 +591,6 @@
                 startDate: document.getElementById('item-start-date').value,
                 deadline: document.getElementById('item-deadline').value,
                 progress: parseInt(progressInput.value),
-                lastWeekProgress: parseInt(lastWeekProgressInput.value) || 0,
                 helpMessage: helpMessageInput.value
             };
 


### PR DESCRIPTION
## Summary
- add progress range slider with +/-10 controls
- remove last week progress field
- rename help message to '留言板' with hint text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884c80335cc8326a0b50e536fe504ff