### PR TITLE
Add local profile images for additional staff

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@ const currentDate = new Date();
 
 let staffData = [];
 
-const localProfileImages = { '盧英云': '盧英云.png', '陳詩芸': '陳詩芸.jpg', '楊宜婷': '楊宜婷.png','黃惠津': '黃惠津.png','王嬿茹': '王嬿茹.png','侯昱瑾': '侯昱瑾.png','高瑞穗': '高瑞穗.png','林盟淦': '林盟淦.png','吳曉琪': '吳曉琪.png','許淑怡': '許淑怡.png','林汶秀': '林汶秀.png','林淑雅': '林淑雅.png','廖家德': '廖家德.jpg','劉雯': '劉雯.jpg','楊依玲': '楊依玲.png','李迎真': '李迎真.png'};
+const localProfileImages = { '盧英云': '盧英云.png', '陳詩芸': '陳詩芸.jpg', '楊宜婷': '楊宜婷.png','黃惠津': '黃惠津.png','王嬿茹': '王嬿茹.png','侯昱瑾': '侯昱瑾.png','高瑞穗': '高瑞穗.png','林盟淦': '林盟淦.png','吳曉琪': '吳曉琪.png','許淑怡': '許淑怡.png','林汶秀': '林汶秀.png','林淑雅': '林淑雅.png','廖家德': '廖家德.jpg','劉雯': '劉雯.jpg','楊依玲': '楊依玲.png','李迎真': '李迎真.png','蔡長志': '蔡長志.png','郭妍伶': '郭妍伶.png'};
 
 const groupData = {
     'teaching-center': '教學中心', 'fdc': '教師培育中心', 'resident': '住院醫師訓練小組',


### PR DESCRIPTION
## Summary
- add local profile image entries for 蔡長志 and 郭妍伶 in the script data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca5677fd60832688d87851cf7290ae