### PR TITLE
Add 4200logo to project dashboard header

### DIFF
--- a/project.html
+++ b/project.html
@@ -123,9 +123,12 @@
     <header class="bg-white shadow-md border-b-2 border-gray-200">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 py-4">
             <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
-                <div class="text-center sm:text-left">
-                    <h1 class="text-3xl font-black text-gray-900 tracking-wider">教學部-專案儀表板</h1>
-                    <p class="text-sm text-gray-500 mt-1">即時追蹤所有進行中的專案與任務</p>
+                <div class="flex flex-col sm:flex-row sm:items-center gap-4 text-center sm:text-left">
+                    <img src="4200logo.png" alt="4200logo" class="w-20 h-20 object-contain mx-auto sm:mx-0">
+                    <div>
+                        <h1 class="text-3xl font-black text-gray-900 tracking-wider">教學部-專案儀表板</h1>
+                        <p class="text-sm text-gray-500 mt-1">即時追蹤所有進行中的專案與任務</p>
+                    </div>
                 </div>
                 <div class="flex flex-wrap items-center justify-center sm:justify-end gap-2 sm:gap-4">
                     <div class="relative">


### PR DESCRIPTION
## Summary
- display the new 4200logo image next to the 教學部-專案儀表板 header for improved branding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cab2a7193c8326aec75b83954b4933